### PR TITLE
test: add extractTagPrefix tests

### DIFF
--- a/tests/extractTagPrefix.spec.ts
+++ b/tests/extractTagPrefix.spec.ts
@@ -2,14 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { extractTagPrefix } from '../src/utils';
 
 describe('extractTagPrefix', () => {
-  it('returns prefix unchanged when no wildcard present', () => {
-    expect(extractTagPrefix('')).toBe('');
-    expect(extractTagPrefix('v')).toBe('v');
-  });
+  it.each(['', 'v'])(
+    'returns prefix %s unchanged when no wildcard present',
+    (prefix) => {
+      expect(extractTagPrefix(prefix)).toBe(prefix);
+    }
+  );
 
-  it('removes trailing wildcard when present', () => {
-    expect(extractTagPrefix('*')).toBe('');
-    expect(extractTagPrefix('v*')).toBe('v');
+  it.each([
+    ['*', ''],
+    ['v*', 'v'],
+  ])('removes trailing wildcard from %s', (input, expected) => {
+    expect(extractTagPrefix(input)).toBe(expected);
   });
 
   it.each(['v*beta', 'v**', '*foo', 'foo*bar'])(


### PR DESCRIPTION
## Summary
- add coverage for extractTagPrefix utility with valid and invalid patterns

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_689de3008774832894fee6c308177dfe