### PR TITLE
docs: document tag prefix wildcard support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'Github secrets token'
     required: true
   tag_prefix:
-    description: 'Prefix added to the generated release tag'
+    description: 'Prefix added to the generated release tag; supports an optional * wildcard only at the end for prefix matching'
     required: true
   tag_template:
     description: 'Template format based in which release tag is generated'

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@
 - The action sets an output variable named `next_release_tag`, which can be used to create the next release.
 - It uses the previous release tag and increments it based on the year, month, date, and iteration count.
 - The action supports creating release tags based on the template given to the action. Refer to the [Templating System](https://github.com/amitsingh-007/next-release-tag#templating-system) section for more information.
+- Supports prefix wildcard tag prefixes (e.g., `v*`) to automatically use the latest tag starting with the prefix. Only prefix-based wildcard matching is supported.
 - This action is recommended to be used with `softprops/action-gh-release` or `ncipollo/release-action` to create the release.
 - The minimum supported Node.js version is v20.
 
@@ -11,11 +12,11 @@
 
 `github_token`: The Github Secret `GITHUB_TOKEN` or `Personal Access Token`. This is a required input.
 
-`tag_prefix`: The prefix to be added to the generated release tag. Pass as `''` to remove prefix in the generated output. This is a required input.
+`tag_prefix`: The prefix to be added to the generated release tag. Pass `''` to remove it. Append a `*` to fetch the latest tag with the same prefix (e.g., `v*`). Only a single wildcard is supported, and it must be at the end of the prefix. This is a required input.
 
 `tag_template`: A preconfigured static template based on which the new release tag will be generated. Please check the [Templating System](https://github.com/amitsingh-007/next-release-tag#templating-system) section for more information. This is a required input.
 
-`previous_tag`: Pass this to override previous tag value and not fetch previous release tag. This is an optional input.
+`previous_tag`: Pass this to override the automatically detected previous tag instead of fetching it. This is an optional input.
 
 ## Outputs
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-warning-comments
-// TODO: write tests
 export const extractTagPrefix = (tagPrefix: string) => {
   const wildcardCount = tagPrefix.match(/\*/g)?.length;
   // If no wildcard is present, return the tagPrefix as is


### PR DESCRIPTION
## Summary
- document wildcard prefix usage
- remove obsolete TODO from extractTagPrefix
- clarify that `tag_prefix` only supports prefix wildcard matching
- mention wildcard support for `tag_prefix` in action.yml
- note the `tag_prefix` wildcard is optional in action.yml
- clarify readme to note only a single trailing wildcard is supported

## Testing
- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_689e145c6d80832894cd54760e07bcf3