### PR TITLE
Move rimraf to devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   },
   "dependencies": {
     "@actions/core": "1.11.1",
-    "@actions/github": "6.0.1",
-    "rimraf": "6.0.1"
+    "@actions/github": "6.0.1"
   },
   "devDependencies": {
     "@vercel/ncc": "0.38.3",
     "husky": "9.1.7",
+    "rimraf": "6.0.1",
     "tsx": "4.20.4",
     "typescript": "5.9.2",
     "vitest": "3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@actions/github':
         specifier: 6.0.1
         version: 6.0.1
-      rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
     devDependencies:
       '@vercel/ncc':
         specifier: 0.38.3
@@ -24,6 +21,9 @@ importers:
       husky:
         specifier: 9.1.7
         version: 9.1.7
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
       tsx:
         specifier: 4.20.4
         version: 4.20.4


### PR DESCRIPTION
rimraf was previously listed as a production dependency. This change moves it to devDependencies, reflecting its use only in development scripts.